### PR TITLE
Require all DHT entries to be namespaced.

### DIFF
--- a/selection.go
+++ b/selection.go
@@ -2,7 +2,6 @@ package record
 
 import (
 	"errors"
-	"strings"
 )
 
 // A SelectorFunc selects the best value for the given key from
@@ -16,15 +15,14 @@ func (s Selector) BestRecord(k string, recs [][]byte) (int, error) {
 		return 0, errors.New("no records given!")
 	}
 
-	parts := strings.Split((string(k)), "/")
-	if len(parts) < 3 {
-		log.Infof("Record key does not have selectorfunc: %s", k)
-		return 0, errors.New("record key does not have selectorfunc")
+	ns, _, err := splitPath(k)
+	if err != nil {
+		return 0, err
 	}
 
-	sel, ok := s[parts[1]]
+	sel, ok := s[ns]
 	if !ok {
-		log.Infof("Unrecognized key prefix: %s", parts[1])
+		log.Infof("Unrecognized key prefix: %s", ns)
 		return 0, ErrInvalidRecordType
 	}
 

--- a/selection.go
+++ b/selection.go
@@ -12,7 +12,7 @@ type Selector map[string]SelectorFunc
 
 func (s Selector) BestRecord(k string, recs [][]byte) (int, error) {
 	if len(recs) == 0 {
-		return 0, errors.New("no records given!")
+		return 0, errors.New("no records given")
 	}
 
 	ns, _, err := splitPath(k)

--- a/selection_test.go
+++ b/selection_test.go
@@ -1,0 +1,33 @@
+package record
+
+import (
+	"testing"
+)
+
+func TestBestRecord(t *testing.T) {
+	sel := Selector{}
+	sel["pk"] = PublicKeySelector
+
+	i, err := sel.BestRecord("/pk/thing", [][]byte{[]byte("first"), []byte("second")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if i != 0 {
+		t.Error("expected to select first record")
+	}
+
+	_, err = sel.BestRecord("/pk/thing", nil)
+	if err == nil {
+		t.Fatal("expected error for no records")
+	}
+
+	_, err = sel.BestRecord("/other/thing", [][]byte{[]byte("first"), []byte("second")})
+	if err == nil {
+		t.Fatal("expected error for unregistered ns")
+	}
+
+	_, err = sel.BestRecord("bad", [][]byte{[]byte("first"), []byte("second")})
+	if err == nil {
+		t.Fatal("expected error for bad key")
+	}
+}

--- a/validation_test.go
+++ b/validation_test.go
@@ -11,6 +11,47 @@ import (
 
 var OffensiveKey = "CAASXjBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQDjXAQQMal4SB2tSnX6NJIPmC69/BT8A8jc7/gDUZNkEhdhYHvc7k7S4vntV/c92nJGxNdop9fKJyevuNMuXhhHAgMBAAE="
 
+func TestSplitPath(t *testing.T) {
+	ns, key, err := splitPath("/foo/bar/baz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ns != "foo" {
+		t.Errorf("wrong namespace: %s", ns)
+	}
+	if key != "bar/baz" {
+		t.Errorf("wrong key: %s", key)
+	}
+
+	ns, key, err = splitPath("/foo/bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ns != "foo" {
+		t.Errorf("wrong namespace: %s", ns)
+	}
+	if key != "bar" {
+		t.Errorf("wrong key: %s", key)
+	}
+
+	for _, badP := range []string{
+		"foo/bar/baz",
+		"//foo/bar/baz",
+		"/ns",
+		"ns",
+		"ns/",
+		"",
+		"//",
+		"/",
+		"////",
+	} {
+		_, _, err := splitPath(badP)
+		if err == nil {
+			t.Errorf("expected error for bad path: %s", badP)
+		}
+	}
+}
+
 func validatePk(k string, pkb []byte) error {
 	ns, k, err := splitPath(k)
 	if err != nil {

--- a/validation_test.go
+++ b/validation_test.go
@@ -52,6 +52,38 @@ func TestSplitPath(t *testing.T) {
 	}
 }
 
+func TestIsSigned(t *testing.T) {
+	v := Validator{}
+	v["sign"] = &ValidChecker{
+		Sign: true,
+	}
+	v["nosign"] = &ValidChecker{
+		Sign: false,
+	}
+	yes, err := v.IsSigned("/sign/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !yes {
+		t.Error("expected ns 'sign' to be signed")
+	}
+	yes, err = v.IsSigned("/nosign/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if yes {
+		t.Error("expected ns 'nosign' to not be signed")
+	}
+	_, err = v.IsSigned("/bad/a")
+	if err == nil {
+		t.Error("expected ns 'bad' to return an error")
+	}
+	_, err = v.IsSigned("bd")
+	if err == nil {
+		t.Error("expected bad ns to return an error")
+	}
+}
+
 func validatePk(k string, pkb []byte) error {
 	ns, k, err := splitPath(k)
 	if err != nil {


### PR DESCRIPTION
This:

1. Returns a validation error for DHT entries that don't have a `/ns/` prefix.
2. Splits out the namespace for easier validation.

This *does not* cause any issues with the providers stuff because we use a separate system for that.

depends on #11
  