### PR TITLE
don't treat a signature as valid if verification fails

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -134,7 +134,7 @@ func CheckRecordSig(r *pb.Record, pk ci.PubKey) error {
 	blob := RecordBlobForSig(r)
 	good, err := pk.Verify(blob, r.Signature)
 	if err != nil {
-		return nil
+		return err
 	}
 	if !good {
 		return errors.New("invalid record signature")

--- a/validation.go
+++ b/validation.go
@@ -132,11 +132,7 @@ var PublicKeyValidator = &ValidChecker{
 
 func CheckRecordSig(r *pb.Record, pk ci.PubKey) error {
 	blob := RecordBlobForSig(r)
-	good, err := pk.Verify(blob, r.Signature)
-	if err != nil {
-		return err
-	}
-	if !good {
+	if good, err := pk.Verify(blob, r.Signature); err != nil || !good {
 		return errors.New("invalid record signature")
 	}
 	return nil

--- a/validation_test.go
+++ b/validation_test.go
@@ -127,4 +127,25 @@ func TestVerifyRecordSigned(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	// New Public Key
+	_, pubk2, err := ci.GenerateKeyPairWithReader(ci.RSA, 1024, u.NewSeededRand(20))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check against wrong public key.
+	err = CheckRecordSig(r, pubk2)
+	if err == nil {
+		t.Error("signature should not validate with bad key")
+	}
+
+	// Corrupt record.
+	r.Value[0] = 1
+
+	// Check bad data against correct key
+	err = CheckRecordSig(r, pubk)
+	if err == nil {
+		t.Error("signature should not validate with bad data")
+	}
 }


### PR DESCRIPTION
Note: this does *not* impact the security of IPNS. We actually have a second
signature for that.